### PR TITLE
Add example JS fix for invalid token syntax error

### DIFF
--- a/fix_example.js
+++ b/fix_example.js
@@ -1,0 +1,11 @@
+/**
+ * Example demonstrating a fix for 'Invalid or unexpected token' error
+ */
+
+// Original problematic code would be:
+// let signature = Ͽ(\u1D49); // This causes SyntaxError
+
+// Corrected version using a string literal:
+let signature = "\u03FF(\u1D49)";
+
+console.log(signature);


### PR DESCRIPTION
## Summary
- show how to resolve an `Invalid or unexpected token` error in JavaScript

## Testing
- `node fix_example.js`


------
https://chatgpt.com/codex/tasks/task_e_6841c606f7748329943fa529e7d8e0c7

## Summary by Sourcery

Enhancements:
- Introduce fix_example.js to show the corrected syntax using unicode escapes for tokens.